### PR TITLE
Updated app conf so app will run once deployed

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,1 +1,13 @@
 # https://www.playframework.com/documentation/latest/Configuration
+
+# you will need to set a secret for the app to run in "prod" mode. this can either be done in the conf file here or
+# (preferably) via an environmental variable i.e. APPLICATION_SECRET
+play.crypto.secret="changeme"
+play.crypto.secret=${?APPLICATION_SECRET}
+
+play.filters.hosts {
+  # A list of valid hosts (e.g. "example.com") or suffixes of valid hosts (e.g. ".example.com")
+  # Note that ".example.com" will match example.com and any subdomain of example.com, with or without a trailing dot.
+  # "." matches all domains, and "" matches an empty or nonexistent host.
+  allowed = ["localhost", ".local", ".herokuapp.com"]
+}


### PR DESCRIPTION
Added:

* The default value for the crypto secret so people know what to change and how
* The heroku domain so that the app will run on Heroku "out of the box"

I know we're not limiting ourselves on where the application is going to be deployed but I'd wager that most people will use Heroku so it seemed a safe bet to be a little opinionated & add that in - of course when people clone the repo they can change it to whatever they like.