### PR TITLE
Fix for opponentName in StartControllerSpec

### DIFF
--- a/test/controllers/StartControllerSpec.scala
+++ b/test/controllers/StartControllerSpec.scala
@@ -12,7 +12,7 @@ class StartControllerSpec extends PlaySpec with GuiceOneAppPerTest {
     "return 200 for a POST" in {
       val json =
         """{
-          | "lastOpponentMove": "PAPER",
+          | "opponentName": "ABC123",
           | "pointsToWin": 1000,
           | "maxRounds": 2000,
           | "dynamiteCount": 100


### PR DESCRIPTION
according to the readme file, the start controller spec json sample should contain an opponentName property instead of a lastOpponentMove property.